### PR TITLE
Passing `extension_options` values to the `register` function of zope.sqlalchemy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Change log
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix transaction rollback with DBAPI cursor.execute.
+  (`#17 <https://github.com/zopefoundation/z3c.sqlalchemy/issues/17>`_)
 
 
 1.5.2 (2020-11-13)

--- a/src/z3c/sqlalchemy/base.py
+++ b/src/z3c/sqlalchemy/base.py
@@ -41,7 +41,7 @@ class ZopeWrapper(object):
             create_session() or sessionmaker()
 
             'extension_options' - optional keyword argument passed to
-            ZopeTransactionExtension()
+            register() of zope.sqlalchemy
 
             'transactional' - True|False, only used by SQLAlchemyDA,
                               *don't touch it*
@@ -142,4 +142,4 @@ class ZopeWrapper(object):
                                             twophase=self.twophase,
                                             autoflush=True,
                                             **self.session_options))
-        register(self._sessionmaker)
+        register(self._sessionmaker, **self.extension_options)


### PR DESCRIPTION
The session status remains `active` if the extension_options values are not passed to the `register` function of `zope.sqlalchemy`.

This leads to the transaction rollback on cursor.execute operations.

The session status should be marked as `changed` after the cursor.execute operation for the transaction to commit.

This is done by passing
`extension_options={'initial_state': 'invalidated'}`

https://github.com/zopefoundation/Products.SQLAlchemyDA/blob/2.0/src/Products/SQLAlchemyDA/da.py#L261

The z3c.sqlalchemy should send the `extension_options` to the `register` function of `zope.sqlalchemy`

This fix should go to `z3c.sqlalchemy > 1.4.0`

Cherry picked from https://github.com/zopefoundation/z3c.sqlalchemy/pull/18 .