### PR TITLE
The session property returns a fresh session everytime it is invoked

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Change log
 2.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Partially revert commit fb7d533aae819dc7e1aef8322c2f2d60a9a1b5d0
+  which caused the sqlalchemy session instance to be persisted as an instance attribute.
+  (`#21 <https://github.com/zopefoundation/z3c.sqlalchemy/issues/21>`_)
 
 
 2.1.1 (2023-09-06)

--- a/src/z3c/sqlalchemy/base.py
+++ b/src/z3c/sqlalchemy/base.py
@@ -102,7 +102,7 @@ class ZopeWrapper:
     @property
     def session(self):
         """ Return thread-local session """
-        return self._session
+        return self._sessionmaker()
 
     @property
     def connection(self):
@@ -140,4 +140,3 @@ class ZopeWrapper:
                                             autoflush=True,
                                             **self.session_options))
         register(self._sessionmaker, **self.extension_options)
-        self._session = self._sessionmaker()


### PR DESCRIPTION
Partially revert commit fb7d533aae819dc7e1aef8322c2f2d60a9a1b5d0 which caused the sqlalchemy session instance to be persisted as an instance attribute. Fixes #21
Closes #22.