### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Change log
 3.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+  - Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the  namespace of the package to versions using a PEP 420 namespace.
 
 
 2.3 (2025-04-04)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Change log
 ==========
 
-2.4 (unreleased)
+3.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def _read_file(filename):
 
 README = _read_file('README.rst')
 CHANGES = _read_file('CHANGES.rst')
-version = '2.4.dev0'
+version = '3.0.dev0'
 
 
 setup(name='z3c.sqlalchemy',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@
 
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -58,11 +57,8 @@ setup(name='z3c.sqlalchemy',
           'Programming Language :: Python :: 3.12',
           'Programming Language :: Python :: 3.13',
       ],
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
       include_package_data=True,
       zip_safe=False,
-      namespace_packages=['z3c'],
       python_requires='>=3.9',
       install_requires=[
           'setuptools',

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the  namespace of the package to versions using a PEP 420 namespace.**
- **Switch to PEP 420 native namespace.**
